### PR TITLE
Update IPoTypes.sol

### DIFF
--- a/src/Nethereum.Commerce.Contracts/Contracts/IPoTypes.sol
+++ b/src/Nethereum.Commerce.Contracts/Contracts/IPoTypes.sol
@@ -25,14 +25,10 @@ interface IPoTypes
 
         address buyerAddress;              // contract managed, buyer EoA address holding currency and "owner" of the PO
         address buyerWalletAddress;        // contract managed, buyer wallet contract address, needed to locate contract when sending events from PoMain contract        
-        bytes32 buyerSysId;                // [B2B only] contract managed, global id of the buyer system
-        bytes32 buyerPurchaseOrderNumber;  // [B2B only] buyer system managed
-        bytes32 buyerViewVendorId;         // [B2B only] buyer system managed, vendor (the seller from the buyer viewpoint)
-
+        
         bytes32 sellerSysId;               // TODO QUESTION - how does this get specified? contract managed, global id of the seller system
         bytes32 sellerCorrelationId        // seller system managed, used to correlate e.g. a shopping cart from the UI (which could hold postal address) with a on-chain PO creation request (which does not have postal address)
-        bytes32 sellerViewCustomerId;      // [B2B only] seller system managed, customer (the buyer from the seller viewpoint)
-
+        
         uint poCreateDate;                 // buyer UI managed, po creation unix timestamp
         
         PoItem poItems[];                  // dynamic array of po items, TODO impose configurable max of eg 16, low enough that contract can iterate all
@@ -44,11 +40,9 @@ interface IPoTypes
         
         bytes32 soNumber                   // seller system (eg eShop) managed (any numbering allowed, could be same as PO number and PO item)
         bytes32 soItemNumer                // seller system (eg eShop) managed (any numbering allowed, could be same as PO number and PO item)
-        
-        bytes32 buyerProductId;            // [B2B only] buyer system managed, material that represents productId (if different)
-        bytes32 productId;                 // buyer UI managed, product id from product registry
-        bytes32 sellerProductId;           // [B2B only] seller system managed, material that represents productId (if different)        
                 
+        bytes32 productId;                 // buyer UI managed, product id from product registry
+                        
         uint32 quantity;                   // buyer UI managed, regular quantity, eg 4
         bytes32 unit;                      // buyer UI managed, regular quantity units, eg PC pieces (TODO are there ISO codes for this?)        
         bytes32 quantityErc20Symbol;       // TODO who manages, symbol of the ERC20 that represents this productId (assume token quantity same as quantity above)

--- a/src/Nethereum.Commerce.Contracts/Contracts/IPoTypes.sol
+++ b/src/Nethereum.Commerce.Contracts/Contracts/IPoTypes.sol
@@ -24,12 +24,13 @@ interface IPoTypes
         uint64 poNumber;                   // contract managed, PO header key
 
         address buyerAddress;              // contract managed, buyer EoA address holding currency and "owner" of the PO
-        address buyerWalletAddress;        // contract managed, buyer wallet contract address, needed to locate contract when sending events from PoMain contract
+        address buyerWalletAddress;        // contract managed, buyer wallet contract address, needed to locate contract when sending events from PoMain contract        
         bytes32 buyerSysId;                // [B2B only] contract managed, global id of the buyer system
         bytes32 buyerPurchaseOrderNumber;  // [B2B only] buyer system managed
         bytes32 buyerViewVendorId;         // [B2B only] buyer system managed, vendor (the seller from the buyer viewpoint)
 
         bytes32 sellerSysId;               // TODO QUESTION - how does this get specified? contract managed, global id of the seller system
+        bytes32 sellerCorrelationId        // seller system managed, used to correlate e.g. a shopping cart from the UI (which could hold postal address) with a on-chain PO creation request (which does not have postal address)
         bytes32 sellerViewCustomerId;      // [B2B only] seller system managed, customer (the buyer from the seller viewpoint)
 
         uint poCreateDate;                 // buyer UI managed, po creation unix timestamp

--- a/src/Nethereum.Commerce.Contracts/Contracts/IPoTypes.sol
+++ b/src/Nethereum.Commerce.Contracts/Contracts/IPoTypes.sol
@@ -30,12 +30,12 @@ interface IPoTypes
 
         bytes32 productId;                 // buyer UI managed, product id from product registry
 
-        uint32 quantity;                   // buyer UI managed, regular quantity, eg 4
+        uint quantity;                     // buyer UI managed, regular quantity, eg 4
         bytes32 unit;                      // buyer UI managed, regular quantity units, eg PC pieces (TODO are there ISO codes for this?)        
         bytes32 quantityErc20Symbol;       // TODO who manages, symbol of the ERC20 that represents this productId (assume token quantity same as quantity above)
         address quantityErc20Address;      // TODO who manages, contract address of the ERC20 that represents this productId
 
-        uint32 value;                      // buyer UI managed, value in the units of the ERC20 that is making the payment eg DAI has token precision 18, so 1120000000000000000 DAI is 1.12 USD
+        uint value;                        // buyer UI managed, value in the units of the ERC20 that is making the payment eg DAI has token precision 18, so 1120000000000000000 DAI is 1.12 USD
         bytes32 currencyErc20Symbol;       // buyer UI managed, symbol of the ERC20 that is making payment, eg DAI
         address currencyErc20Address;      // buyer UI managed, contract address of the ERC20 that is making payment 
 

--- a/src/Nethereum.Commerce.Contracts/Contracts/IPoTypes.sol
+++ b/src/Nethereum.Commerce.Contracts/Contracts/IPoTypes.sol
@@ -1,3 +1,5 @@
+pragma solidity ^0.6.1;
+
 interface IPoTypes
 {
     enum PoItemStatus
@@ -10,7 +12,7 @@ interface IPoTypes
         CompletedPaid,          // 5  PO item is complete and escrow funds released to the buyer wallet           | 4->5 managed by seller wallet contract fn call from seller UI
         CancelledRefund         // 6  PO item has been successfully cancelled and funds refunded to buyer wallet  | 1->6 or 2->6 managed by seller wallet contract fn call from seller UI, at discretion of seller (poss break out into own field of po item payment status)
     }
-    
+
     enum PoItemCancelStatus
     {
         Initial,                // 0  default to empty, no request made
@@ -19,42 +21,43 @@ interface IPoTypes
         RequestAccepted         // 3  PO item has had cancellation accepted  | 1->3 managed by seller wallet contract fn call from seller UI 
     }
 
-    struct Po
-    {
-        uint64 poNumber;                   // contract managed, PO header key
-
-        address buyerAddress;              // contract managed, buyer EoA address holding currency and "owner" of the PO
-        address buyerWalletAddress;        // contract managed, buyer wallet contract address, needed to locate contract when sending events from PoMain contract        
-        
-        bytes32 sellerSysId;               // TODO QUESTION - how does this get specified? contract managed, global id of the seller system
-        bytes32 sellerCorrelationId        // seller system managed, used to correlate e.g. a shopping cart from the UI (which could hold postal address) with a on-chain PO creation request (which does not have postal address)
-        
-        uint poCreateDate;                 // buyer UI managed, po creation unix timestamp
-        
-        PoItem poItems[];                  // dynamic array of po items, TODO impose configurable max of eg 16, low enough that contract can iterate all
-    }
-    
     struct PoItem
     {
-        uint8 poItemNumber                 // contract managed, PO item key
-        
-        bytes32 soNumber                   // seller system (eg eShop) managed (any numbering allowed, could be same as PO number and PO item)
-        bytes32 soItemNumer                // seller system (eg eShop) managed (any numbering allowed, could be same as PO number and PO item)
-                
+        uint8 poItemNumber;                // contract managed, PO item key
+
+        bytes32 soNumber;                  // seller system (eg eShop) managed (any numbering allowed, could be same as PO number and PO item)
+        bytes32 soItemNumer;               // seller system (eg eShop) managed (any numbering allowed, could be same as PO number and PO item)
+
         bytes32 productId;                 // buyer UI managed, product id from product registry
-                        
+
         uint32 quantity;                   // buyer UI managed, regular quantity, eg 4
         bytes32 unit;                      // buyer UI managed, regular quantity units, eg PC pieces (TODO are there ISO codes for this?)        
         bytes32 quantityErc20Symbol;       // TODO who manages, symbol of the ERC20 that represents this productId (assume token quantity same as quantity above)
         address quantityErc20Address;      // TODO who manages, contract address of the ERC20 that represents this productId
-        
+
         uint32 value;                      // buyer UI managed, value in the units of the ERC20 that is making the payment eg DAI has token precision 18, so 1120000000000000000 DAI is 1.12 USD
         bytes32 currencyErc20Symbol;       // buyer UI managed, symbol of the ERC20 that is making payment, eg DAI
         address currencyErc20Address;      // buyer UI managed, contract address of the ERC20 that is making payment 
-  
+
         PoItemStatus status;               // contract managed for create, then seller system managed
         uint goodsIssueDate;               // contract managed at point of goods issue, the goods issue unix timestamp
         uint escrowReleaseDate;            // contract managed at point of goods issue, it is the goods issue unix timestamp + escrow days eg 30 days        
         PoItemCancelStatus cancelStatus;   // contract managed from buyer UI and seller UI fn calls
     }
-}   
+
+    struct Po
+    {
+        uint poNumber;                     // contract managed, PO header key, leave blank at PO creation time
+
+        address buyerAddress;              // contract managed, buyer EoA address holding currency and "owner" of the PO
+        address buyerWalletAddress;        // contract managed, buyer wallet contract address, needed to locate contract when sending events from PoMain contract        
+        uint buyerNonce;                   // contract managed, buyer UI assigned. buyerAddress+buyerNonce uniquely identifies a single poNumber
+
+        bytes32 sellerSysId;               // buyer UI managed, allocated by seller system to identify their shop
+
+        uint poCreateDate;                 // buyer UI managed, po creation unix timestamp
+
+        PoItem[] poItems;                  // dynamic array of po items, TODO impose configurable max of eg 16, low enough that contract can iterate all
+    }
+
+}

--- a/src/Nethereum.Commerce.Contracts/Contracts/nethereum-gen.settings
+++ b/src/Nethereum.Commerce.Contracts/Contracts/nethereum-gen.settings
@@ -2,6 +2,6 @@
     "projectName": "Nethereum.Commerce.Contracts",
     "namespace": "Nethereum.Commerce.Contracts",
     "lang": 0,
-    "autoCodeGen": true,
+    "autoCodeGen": false,
     "projectPath": "../"
 }


### PR DESCRIPTION
Updates after meeting with Dave. We added sellerCorrelationId - this is seller system managed, and used to correlate e.g. a shopping cart from the UI (which could hold eg a postal address) with a on-chain PO creation request (which does not have the postal address).